### PR TITLE
fix(ci): derive Go version from go.mod and pin govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # GitHub Actions CI/CD Pipeline for notebook
 # Meeting and Notes Management App with Tailscale Integration
-# Go Version: 1.26.3
+# Go version is read from go.mod (go-version-file) — no manual sync required
 
 name: CI
 
@@ -11,7 +11,6 @@ on:
     branches: [master]
 
 env:
-  GO_VERSION: "1.26.3"
   CGO_ENABLED: "0"
 
 jobs:
@@ -28,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js
@@ -82,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js
@@ -135,7 +134,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js
@@ -167,7 +166,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js
@@ -204,7 +203,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,9 @@ jobs:
         run: task build:frontend
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Renovate tracks this version via customManagers regex in renovate.json.
+        # Pinned: @latest resolved to v1.4.0 which panics on generics (x/tools v0.46.0 bug).
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         run: govulncheck -show verbose ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,6 @@ permissions:
   contents: write
   packages: write
 
-env:
-  GO_VERSION: "1.26.3"
-
 jobs:
   verify:
     name: Verify (lint + test)
@@ -27,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js
@@ -73,7 +70,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Setup Node.js

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zorak1103/notebook
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/renovate.json
+++ b/renovate.json
@@ -82,6 +82,13 @@
       "matchPackageNames": ["golangci/golangci-lint"],
       "automerge": true,
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": "govulncheck minor/patch - automerge",
+      "matchPackageNames": ["golang.org/x/vuln"],
+      "matchManagers": ["regex"],
+      "automerge": true,
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
   "customManagers": [
@@ -94,6 +101,17 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "golangci/golangci-lint",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Track govulncheck version in go install workflow steps",
+      "managerFilePatterns": ["/\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "golang.org/x/vuln/cmd/govulncheck@(?<currentValue>v[\\d.]+)"
+      ],
+      "datasourceTemplate": "go",
+      "depNameTemplate": "golang.org/x/vuln",
       "versioningTemplate": "semver"
     }
   ],


### PR DESCRIPTION
## Problem

Two pre-existing defects in `master`'s CI were blocking all open Renovate PRs:

1. **Pinned `GO_VERSION: "1.26.3"`** with `GOTOOLCHAIN: local` — any PR that bumps the `go` directive past 1.26.3 fails every CI job because Go refuses to build a module that declares a newer minimum than the installed toolchain. This caused PR #65 (all 5 checks fail).

2. **`govulncheck@latest`** resolves to v1.4.0, which panics on Go 1.26 generics:
   ```
   panic: ForEachElement called on type containing *types.TypeParam
   ```
   via `x/tools@v0.46.0` SSA called from `x/vuln@v1.4.0`. This caused PR #66 (govulncheck check fail) and contributed to #65.

## Changes (3 commits)

| Commit | Change |
|--------|--------|
| `c2ffffe` | Switch all `setup-go` steps to `go-version-file: go.mod` — removes the out-of-sync `GO_VERSION` env var entirely |
| `7a03b5a` | Pin `govulncheck@v1.3.0` and add a Renovate entry to track it automatically |
| `9216e92` | Bump `go` directive to `1.26.4` (required to clear a stdlib advisory that surfaced under the new govulncheck) |

## After merge

With the pinned `GO_VERSION` gone and `govulncheck` on a stable release:
- PR #65 (dep bundle, includes `go 1.26.4` bump) should go fully green once rebased
- PR #66 (checkout v6→v7) should lose its govulncheck failure once rebased

## Verification

Branch CI: already green on HEAD `9216e92` before this PR was opened.